### PR TITLE
Vines overhaul

### DIFF
--- a/vines/init.lua
+++ b/vines/init.lua
@@ -42,6 +42,17 @@ local function dig_down(pos, node, digger)
 	end
 end
 
+local function ensure_vine_end(pos, oldnode)
+	local np = {x = pos.x, y = pos.y + 1, z = pos.z}
+	local nn = minetest.get_node(np)
+
+	vine_name_end = oldnode.name:gsub("_middle", "_end")
+
+	if minetest.get_item_group(nn.name, "vines") > 0 then
+		minetest.swap_node(np, { name = vine_name_end, param2 = oldnode.param2 })
+	end
+end
+
 
 vines.register_vine = function( name, defs, biome )
 
@@ -130,6 +141,10 @@ vines.register_vine = function( name, defs, biome )
 		after_dig_node = function(pos, node, metadata, digger)
 			dig_down(pos, node, digger)
 		end,
+
+		after_destruct = function(pos, oldnode)
+			ensure_vine_end(pos, oldnode)
+		end,
 	})
 
 	minetest.register_node( vine_name_middle, {
@@ -151,6 +166,10 @@ vines.register_vine = function( name, defs, biome )
 
 		after_dig_node = function(pos, node, metadata, digger)
 			dig_down(pos, node, digger)
+		end,
+
+		after_destruct = function(pos, oldnode)
+			ensure_vine_end(pos, oldnode)
 		end,
 	})
 

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -83,12 +83,14 @@ vines.register_vine = function( name, defs, biome )
 	local spawn_plants = function(pos, fdir)
 		local max_length = math.random(defs.average_length)
 		local current_length = 1
-		while minetest.get_node({ x=pos.x, y=pos.y - 1, z=pos.z }).name == 'air' and current_length < max_length do
-			minetest.swap_node(pos, { name = vine_name_middle, param2 = fdir })
-			pos.y = pos.y - 1
-			current_length = current_length + 1
+		if minetest.get_node({ x=pos.x, y=pos.y - 1, z=pos.z }).name == 'air' then
+			while minetest.get_node({ x=pos.x, y=pos.y - 1, z=pos.z }).name == 'air' and current_length < max_length do
+				minetest.swap_node(pos, { name = vine_name_middle, param2 = fdir })
+				pos.y = pos.y - 1
+				current_length = current_length + 1
+			end
+			minetest.set_node(pos, { name = vine_name_end, param2 = fdir })
 		end
-		minetest.set_node(pos, { name = vine_name_end, param2 = fdir })
 	end
 
 	local vine_group = 'group:' .. name .. '_vines'

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -3,6 +3,7 @@ vines = {
 	recipes = {}
 }
 
+local enable_vines = minetest.settings:get_bool("vines_enable_vines")
 local enable_rope = minetest.settings:get_bool("vines_enable_rope")
 local enable_roots = minetest.settings:get_bool("vines_enable_roots")
 local enable_standard = minetest.settings:get_bool("vines_enable_standard")
@@ -25,11 +26,13 @@ local S = minetest.get_translator("vines")
 
 -- ITEMS
 
-minetest.register_craftitem("vines:vines", {
-	description = S("Vines"),
-	inventory_image = "vines_item.png",
-	groups = {vines = 1, flammable = 2}
-})
+if enable_vines ~= false then
+	minetest.register_craftitem("vines:vines", {
+		description = S("Vines"),
+		inventory_image = "vines_item.png",
+		groups = {vines = 1, flammable = 2}
+	})
+end
 
 -- FUNCTIONS
 
@@ -86,7 +89,11 @@ vines.register_vine = function( name, defs, biome )
 	local vine_name_middle = 'vines:' .. name .. '_middle'
 	local vine_image_end = "vines_" .. name .. "_end.png"
 	local vine_image_middle = "vines_" .. name .. "_middle.png"
+
 	local drop_node = vine_name_end
+	if enable_vines ~= false then
+		drop_node = "vines:vines"
+	end
 
 	local spawn_plants = function(pos, fdir)
 		local max_length = math.random(defs.average_length)
@@ -121,7 +128,7 @@ vines.register_vine = function( name, defs, biome )
 		walkable = false,
 		climbable = true,
 		wield_image = vine_image_end,
-		drop = "vines:vines",
+		drop = drop_node,
 		sunlight_propagates = true,
 		paramtype = "light",
 		paramtype2 = "wallmounted",
@@ -176,7 +183,7 @@ vines.register_vine = function( name, defs, biome )
 		description = S("Matured") .. " " .. defs.description,
 		walkable = false,
 		climbable = true,
-		drop = "vines:vines",
+		drop = drop_node,
 		sunlight_propagates = true,
 		paramtype = "light",
 		paramtype2 = "wallmounted",

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -37,35 +37,28 @@ end
 -- FUNCTIONS
 
 local function on_dig(pos, node, player)
-	wielded_item = player:get_wielded_item()
-	if wielded_item and wielded_item:get_name() == 'vines:shears' then
-		wielded_item:add_wear(1)
-
-		vine_name_end = node.name:gsub("_middle", "_end")
-		minetest.remove_node(pos)
-		minetest.handle_node_drops(pos, {vine_name_end}, player)
-
-		below_pos = {x = pos.x, y = pos.y - 1, z = pos.z}
-		while minetest.get_item_group(minetest.get_node(below_pos).name, "vines") > 0 do
-			minetest.remove_node(below_pos)
-			minetest.handle_node_drops(below_pos, {vine_name_end}, player)
-			below_pos.y = below_pos.y - 1
-		end
-
-	else
-		minetest.node_dig(pos, node, player)
+	vine_name_end = node.name:gsub("_middle", "_end")
+	drop_item = "vines:vines"
+	if enable_vines == false then
+		drop_item = vine_name_end
 	end
-end
+	
+	wielded_item = player:get_wielded_item()
+	if wielded_item then
+		wielded_item:add_wear(1)
+		if wielded_item:get_name() == 'vines:shears' then
+			drop_item = vine_name_end
+		end
+	end
 
-local function dig_down(pos, node, digger)
+	minetest.remove_node(pos)
+	minetest.handle_node_drops(pos, {drop_item}, player)
 
-	if digger == nil then return end
-
-	local np = {x = pos.x, y = pos.y - 1, z = pos.z}
-	local nn = minetest.get_node(np)
-
-	if minetest.get_item_group(nn.name, "vines") > 0 then
-		minetest.node_dig(np, nn, digger)
+	below_pos = {x = pos.x, y = pos.y - 1, z = pos.z}
+	while minetest.get_item_group(minetest.get_node(below_pos).name, "vines") > 0 do
+		minetest.remove_node(below_pos)
+		minetest.handle_node_drops(below_pos, {drop_item}, player)
+		below_pos.y = below_pos.y - 1
 	end
 end
 
@@ -89,11 +82,6 @@ vines.register_vine = function( name, defs, biome )
 	local vine_name_middle = 'vines:' .. name .. '_middle'
 	local vine_image_end = "vines_" .. name .. "_end.png"
 	local vine_image_middle = "vines_" .. name .. "_middle.png"
-
-	local drop_node = vine_name_end
-	if enable_vines ~= false then
-		drop_node = "vines:vines"
-	end
 
 	local spawn_plants = function(pos, fdir)
 		local max_length = math.random(defs.average_length)
@@ -128,7 +116,7 @@ vines.register_vine = function( name, defs, biome )
 		walkable = false,
 		climbable = true,
 		wield_image = vine_image_end,
-		drop = drop_node,
+		drop = {},
 		sunlight_propagates = true,
 		paramtype = "light",
 		paramtype2 = "wallmounted",
@@ -170,10 +158,6 @@ vines.register_vine = function( name, defs, biome )
 
 		on_dig = on_dig,
 
-		after_dig_node = function(pos, node, metadata, digger)
-			dig_down(pos, node, digger)
-		end,
-
 		after_destruct = function(pos, oldnode)
 			ensure_vine_end(pos, oldnode)
 		end,
@@ -183,7 +167,7 @@ vines.register_vine = function( name, defs, biome )
 		description = S("Matured") .. " " .. defs.description,
 		walkable = false,
 		climbable = true,
-		drop = drop_node,
+		drop = {},
 		sunlight_propagates = true,
 		paramtype = "light",
 		paramtype2 = "wallmounted",
@@ -197,10 +181,6 @@ vines.register_vine = function( name, defs, biome )
 		selection_box = selection_box,
 
 		on_dig = on_dig,
-
-		after_dig_node = function(pos, node, metadata, digger)
-			dig_down(pos, node, digger)
-		end,
 
 		after_destruct = function(pos, oldnode)
 			ensure_vine_end(pos, oldnode)

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -3,13 +3,13 @@ vines = {
 	recipes = {}
 }
 
-local enable_vines = minetest.settings:get_bool("vines_enable_vines")
-local enable_rope = minetest.settings:get_bool("vines_enable_rope")
-local enable_roots = minetest.settings:get_bool("vines_enable_roots")
-local enable_standard = minetest.settings:get_bool("vines_enable_standard")
-local enable_side = minetest.settings:get_bool("vines_enable_side")
-local enable_jungle = minetest.settings:get_bool("vines_enable_jungle")
-local enable_willow = minetest.settings:get_bool("vines_enable_willow")
+local enable_vines = minetest.settings:get_bool("vines_enable_vines", true)
+local enable_rope = minetest.settings:get_bool("vines_enable_rope", true)
+local enable_roots = minetest.settings:get_bool("vines_enable_roots", true)
+local enable_standard = minetest.settings:get_bool("vines_enable_standard", true)
+local enable_side = minetest.settings:get_bool("vines_enable_side", true)
+local enable_jungle = minetest.settings:get_bool("vines_enable_jungle", true)
+local enable_willow = minetest.settings:get_bool("vines_enable_willow", true)
 
 local default_rarity = 90
 local rarity_roots = tonumber(minetest.settings:get("vines_rarity_roots")) or default_rarity

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -186,7 +186,7 @@ vines.register_vine = function( name, defs, biome )
 		end,
 	})
 
-    biome_lib.register_on_generate(biome, spawn_plants)
+	biome_lib.register_on_generate(biome, spawn_plants)
 end
 
 -- ALIASES

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -56,7 +56,7 @@ end
 
 vines.register_vine = function( name, defs, biome )
 
-	local groups = {vines = 1, snappy = 3, flammable = 2, attached_node = 1}
+	local groups = {vines = 1, snappy = 3, flammable = 2}
 	local vine_name_end = 'vines:' .. name .. '_end'
 	local vine_name_middle = 'vines:' .. name .. '_middle'
 	local vine_image_end = "vines_" .. name .. "_end.png"
@@ -111,7 +111,6 @@ vines.register_vine = function( name, defs, biome )
 		on_construct = function(pos)
 
 			local timer = minetest.get_node_timer(pos)
-
 			timer:start(math.random(5, 10))
 		end,
 
@@ -120,7 +119,6 @@ vines.register_vine = function( name, defs, biome )
 			local node = minetest.get_node(pos)
 			local bottom = {x = pos.x, y = pos.y - 1, z = pos.z}
 			local bottom_node = minetest.get_node( bottom )
-
 			if bottom_node.name == "air" then
 
 				if not math.random(defs.average_length) == 1 then

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -3,7 +3,19 @@ vines = {
 	recipes = {}
 }
 
+local enable_rope = minetest.settings:get_bool("vines_enable_rope")
 local enable_roots = minetest.settings:get_bool("vines_enable_roots")
+local enable_standard = minetest.settings:get_bool("vines_enable_standard")
+local enable_side = minetest.settings:get_bool("vines_enable_side")
+local enable_jungle = minetest.settings:get_bool("vines_enable_jungle")
+local enable_willow = minetest.settings:get_bool("vines_enable_willow")
+
+local default_rarity = 90
+local rarity_roots = tonumber(minetest.settings:get("vines_rarity_roots")) or default_rarity
+local rarity_standard = tonumber(minetest.settings:get("vines_rarity_standard")) or default_rarity
+local rarity_side = tonumber(minetest.settings:get("vines_rarity_side")) or default_rarity
+local rarity_jungle = tonumber(minetest.settings:get("vines_rarity_jungle")) or default_rarity
+local rarity_willow = tonumber(minetest.settings:get("vines_rarity_willow")) or default_rarity
 
 -- support for i18n
 local S = minetest.get_translator("vines")
@@ -193,110 +205,112 @@ minetest.register_craft({
 
 -- NODES
 
-minetest.register_node("vines:rope_block", {
-	description = S("Rope"),
-	sunlight_propagates = true,
-	paramtype = "light",
-	tiles = {
-		"default_wood.png^vines_rope.png",
-		"default_wood.png^vines_rope.png",
-		"default_wood.png",
-		"default_wood.png",
-		"default_wood.png^vines_rope.png",
-		"default_wood.png^vines_rope.png",
-	},
-	groups = {flammable = 2, choppy = 2, oddly_breakable_by_hand = 1},
+if enable_rope ~= false then
+	minetest.register_node("vines:rope_block", {
+		description = S("Rope"),
+		sunlight_propagates = true,
+		paramtype = "light",
+		tiles = {
+			"default_wood.png^vines_rope.png",
+			"default_wood.png^vines_rope.png",
+			"default_wood.png",
+			"default_wood.png",
+			"default_wood.png^vines_rope.png",
+			"default_wood.png^vines_rope.png",
+		},
+		groups = {flammable = 2, choppy = 2, oddly_breakable_by_hand = 1},
 
-	after_place_node = function(pos)
+		after_place_node = function(pos)
 
-		local p = {x = pos.x, y = pos.y - 1, z = pos.z}
-		local n = minetest.get_node(p)
+			local p = {x = pos.x, y = pos.y - 1, z = pos.z}
+			local n = minetest.get_node(p)
 
-		if n.name == "air" then
-			minetest.add_node(p, {name = "vines:rope_end"})
+			if n.name == "air" then
+				minetest.add_node(p, {name = "vines:rope_end"})
+			end
+		end,
+
+		after_dig_node = function(pos, node, digger)
+
+			local p = {x = pos.x, y = pos.y - 1, z = pos.z}
+			local n = minetest.get_node(p)
+
+			while n.name == 'vines:rope' or n.name == 'vines:rope_end' do
+
+				minetest.remove_node(p)
+
+				p = {x = p.x, y = p.y - 1, z = p.z}
+				n = minetest.get_node(p)
+			end
 		end
-	end,
+	})
 
-	after_dig_node = function(pos, node, digger)
+	minetest.register_node("vines:rope", {
+		description = S("Rope"),
+		walkable = false,
+		climbable = true,
+		sunlight_propagates = true,
+		paramtype = "light",
+		drop = {},
+		tiles = {"vines_rope.png"},
+		drawtype = "plantlike",
+		groups = {flammable = 2, not_in_creative_inventory = 1},
+		sounds = default.node_sound_leaves_defaults(),
+		selection_box = {
+			type = "fixed",
+			fixed = {-1/7, -1/2, -1/7, 1/7, 1/2, 1/7},
+		},
+	})
 
-		local p = {x = pos.x, y = pos.y - 1, z = pos.z}
-		local n = minetest.get_node(p)
+	minetest.register_node("vines:rope_end", {
+		description = S("Rope"),
+		walkable = false,
+		climbable = true,
+		sunlight_propagates = true,
+		paramtype = "light",
+		drop = {},
+		tiles = {"vines_rope_end.png"},
+		drawtype = "plantlike",
+		groups = {flammable = 2, not_in_creative_inventory = 1},
+		sounds = default.node_sound_leaves_defaults(),
 
-		while n.name == 'vines:rope' or n.name == 'vines:rope_end' do
+		after_place_node = function(pos)
 
-			minetest.remove_node(p)
+			local yesh = {x = pos.x, y = pos.y - 1, z = pos.z}
 
-			p = {x = p.x, y = p.y - 1, z = p.z}
-			n = minetest.get_node(p)
-		end
-	end
-})
+			minetest.add_node(yesh, {name = "vines:rope"})
+		end,
 
-minetest.register_node("vines:rope", {
-	description = S("Rope"),
-	walkable = false,
-	climbable = true,
-	sunlight_propagates = true,
-	paramtype = "light",
-	drop = {},
-	tiles = {"vines_rope.png"},
-	drawtype = "plantlike",
-	groups = {flammable = 2, not_in_creative_inventory = 1},
-	sounds = default.node_sound_leaves_defaults(),
-	selection_box = {
-		type = "fixed",
-		fixed = {-1/7, -1/2, -1/7, 1/7, 1/2, 1/7},
-	},
-})
+		selection_box = {
+			type = "fixed",
+			fixed = {-1/7, -1/2, -1/7, 1/7, 1/2, 1/7},
+		},
 
-minetest.register_node("vines:rope_end", {
-	description = S("Rope"),
-	walkable = false,
-	climbable = true,
-	sunlight_propagates = true,
-	paramtype = "light",
-	drop = {},
-	tiles = {"vines_rope_end.png"},
-	drawtype = "plantlike",
-	groups = {flammable = 2, not_in_creative_inventory = 1},
-	sounds = default.node_sound_leaves_defaults(),
-
-	after_place_node = function(pos)
-
-		local yesh = {x = pos.x, y = pos.y - 1, z = pos.z}
-
-		minetest.add_node(yesh, {name = "vines:rope"})
-	end,
-
-	selection_box = {
-		type = "fixed",
-		fixed = {-1/7, -1/2, -1/7, 1/7, 1/2, 1/7},
-	},
-
-	on_construct = function(pos)
-
-		local timer = minetest.get_node_timer(pos)
-
-		timer:start(1)
-	end,
-
-	on_timer = function( pos, elapsed )
-
-		local p = {x = pos.x, y = pos.y - 1, z = pos.z}
-		local n = minetest.get_node(p)
-
-		if	n.name == "air" then
-
-			minetest.set_node(pos, {name = "vines:rope"})
-			minetest.add_node(p, {name = "vines:rope_end"})
-		else
+		on_construct = function(pos)
 
 			local timer = minetest.get_node_timer(pos)
 
 			timer:start(1)
+		end,
+
+		on_timer = function( pos, elapsed )
+
+			local p = {x = pos.x, y = pos.y - 1, z = pos.z}
+			local n = minetest.get_node(p)
+
+			if	n.name == "air" then
+
+				minetest.set_node(pos, {name = "vines:rope"})
+				minetest.add_node(p, {name = "vines:rope_end"})
+			else
+
+				local timer = minetest.get_node_timer(pos)
+
+				timer:start(1)
+			end
 		end
-	end
-})
+	})
+end
 
 -- SHEARS
 
@@ -323,90 +337,102 @@ if enable_roots ~= false then
 		"default:dirt_with_grass",
 		"default:dirt"
 	}
+
+	vines.register_vine('root',
+		{description = S("Roots"), average_length = 9}, {
+		choose_random_wall = true,
+		avoid_nodes = {"vines:root_middle"},
+		avoid_radius = 5,
+		surface = spawn_root_surfaces,
+		spawn_on_bottom = true,
+		plantlife_limit = -0.6,
+		rarity = rarity_roots,
+	--	humidity_min = 0.4,
+	})
 end
 
-vines.register_vine('root',
-	{description = S("Roots"), average_length = 9}, {
-	choose_random_wall = true,
-	avoid_nodes = {"vines:root_middle"},
-	avoid_radius = 5,
-	surface = spawn_root_surfaces,
-	spawn_on_bottom = true,
-	plantlife_limit = -0.6,
---	humidity_min = 0.4,
-})
+if enable_standard ~= false then
+	vines.register_vine('vine',
+		{description = S("Vines"), average_length = 5}, {
+		choose_random_wall = true,
+		avoid_nodes = {"group:vines"},
+		avoid_radius = 5,
+		surface = {
+	--		"default:leaves",
+			"default:jungleleaves",
+			"moretrees:jungletree_leaves_red",
+			"moretrees:jungletree_leaves_yellow",
+			"moretrees:jungletree_leaves_green"
+		},
+		spawn_on_bottom = true,
+		plantlife_limit = -0.9,
+		rarity = rarity_standard,
+	--	humidity_min = 0.7,
+	})
+end
 
-vines.register_vine('vine',
-	{description = S("Vines"), average_length = 5}, {
-	choose_random_wall = true,
-	avoid_nodes = {"group:vines"},
-	avoid_radius = 5,
-	surface = {
---		"default:leaves",
-		"default:jungleleaves",
-		"moretrees:jungletree_leaves_red",
-		"moretrees:jungletree_leaves_yellow",
-		"moretrees:jungletree_leaves_green"
-	},
-	spawn_on_bottom = true,
-	plantlife_limit = -0.9,
---	humidity_min = 0.7,
-})
+if enable_side ~= false then
+	vines.register_vine('side',
+		{description = S("Vines"), average_length = 6}, {
+		choose_random_wall = true,
+		avoid_nodes = {"group:vines", "default:apple"},
+		avoid_radius = 3,
+		surface = {
+	--		"default:leaves",
+			"default:jungleleaves",
+			"moretrees:jungletree_leaves_red",
+			"moretrees:jungletree_leaves_yellow",
+			"moretrees:jungletree_leaves_green"
+		},
+		spawn_on_side = true,
+		plantlife_limit = -0.9,
+		rarity = rarity_side,
+	--	humidity_min = 0.4,
+	})
+end
 
-vines.register_vine('side',
-	{description = S("Vines"), average_length = 6}, {
-	choose_random_wall = true,
-	avoid_nodes = {"group:vines", "default:apple"},
-	avoid_radius = 3,
-	surface = {
---		"default:leaves",
-		"default:jungleleaves",
-		"moretrees:jungletree_leaves_red",
-		"moretrees:jungletree_leaves_yellow",
-		"moretrees:jungletree_leaves_green"
-	},
-	spawn_on_side = true,
-	plantlife_limit = -0.9,
---	humidity_min = 0.4,
-})
+if enable_jungle ~= false then
+	vines.register_vine("jungle",
+		{description = S("Jungle Vines"), average_length = 7}, {
+		choose_random_wall = true,
+		neighbors = {
+			"default:jungleleaves",
+			"moretrees:jungletree_leaves_red",
+			"moretrees:jungletree_leaves_yellow",
+			"moretrees:jungletree_leaves_green"
+		},
+		avoid_nodes = {
+			"vines:jungle_middle",
+			"vines:jungle_end",
+		},
+		avoid_radius = 5,
+		surface = {
+			"default:jungletree",
+			"moretrees:jungletree_trunk"
+		},
+		spawn_on_side = true,
+		plantlife_limit = -0.9,
+		rarity = rarity_jungle,
+	--	humidity_min = 0.2,
+	})
+end
 
-vines.register_vine("jungle",
-	{description = S("Jungle Vines"), average_length = 7}, {
-	choose_random_wall = true,
-	neighbors = {
-		"default:jungleleaves",
-		"moretrees:jungletree_leaves_red",
-		"moretrees:jungletree_leaves_yellow",
-		"moretrees:jungletree_leaves_green"
-	},
-	avoid_nodes = {
-		"vines:jungle_middle",
-		"vines:jungle_end",
-	},
-	avoid_radius = 5,
-	surface = {
-		"default:jungletree",
-		"moretrees:jungletree_trunk"
-	},
-	spawn_on_side = true,
-	plantlife_limit = -0.9,
---	humidity_min = 0.2,
-})
+if enable_willow ~= false then
+	vines.register_vine( 'willow',
+		{description = S("Willow Vines"), average_length = 9}, {
+		choose_random_wall = true,
+		avoid_nodes = {"vines:willow_middle"},
+		avoid_radius = 5,
+		near_nodes = {'default:water_source'},
+		near_nodes_size = 1,
+		near_nodes_count = 1,
+		near_nodes_vertical = 7,
+		plantlife_limit = -0.8,
+		spawn_on_side = true,
+		surface = {"moretrees:willow_leaves"},
+		rarity = rarity_willow,
+	--	humidity_min = 0.5
+	})
+end
 
-vines.register_vine( 'willow',
-	{description = S("Willow Vines"), average_length = 9}, {
-	choose_random_wall = true,
-	avoid_nodes = {"vines:willow_middle"},
-	avoid_radius = 5,
-	near_nodes = {'default:water_source'},
-	near_nodes_size = 1,
-	near_nodes_count = 1,
-	near_nodes_vertical = 7,
-	plantlife_limit = -0.8,
-	spawn_on_side = true,
-	surface = {"moretrees:willow_leaves"},
---	humidity_min = 0.5
-})
-
-
-print("[Vines] Loaded!")
+print("[Vines] Loaded")

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -482,4 +482,3 @@ else
 	minetest.register_alias('vines:willow_end', 'air')
 end
 
-print("[Vines] Loaded")

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -51,14 +51,11 @@ local function on_dig(pos, node, player)
 		end
 	end
 
-	minetest.remove_node(pos)
-	minetest.handle_node_drops(pos, {drop_item}, player)
-
-	below_pos = {x = pos.x, y = pos.y - 1, z = pos.z}
-	while minetest.get_item_group(minetest.get_node(below_pos).name, "vines") > 0 do
-		minetest.remove_node(below_pos)
-		minetest.handle_node_drops(below_pos, {drop_item}, player)
-		below_pos.y = below_pos.y - 1
+	break_pos = {x = pos.x, y = pos.y, z = pos.z}
+	while minetest.get_item_group(minetest.get_node(break_pos).name, "vines") > 0 do
+		minetest.remove_node(break_pos)
+		minetest.handle_node_drops(break_pos, {drop_item}, player)
+		break_pos.y = break_pos.y - 1
 	end
 end
 
@@ -85,7 +82,7 @@ vines.register_vine = function( name, defs, biome )
 
 	local spawn_plants = function(pos, fdir)
 		local max_length = math.random(defs.average_length)
-		local current_length = 0
+		local current_length = 1
 		while minetest.get_node({ x=pos.x, y=pos.y - 1, z=pos.z }).name == 'air' and current_length < max_length do
 			minetest.swap_node(pos, { name = vine_name_middle, param2 = fdir })
 			pos.y = pos.y - 1

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -18,8 +18,8 @@ local rarity_side = tonumber(minetest.settings:get("vines_rarity_side")) or defa
 local rarity_jungle = tonumber(minetest.settings:get("vines_rarity_jungle")) or default_rarity
 local rarity_willow = tonumber(minetest.settings:get("vines_rarity_willow")) or default_rarity
 
-local growth_min = 60 * 3
-local growth_max = 60 * 6
+local growth_min = tonumber(minetest.settings:get("vines_growth_min")) or 180
+local growth_max = tonumber(minetest.settings:get("vines_growth_max")) or 360
 
 -- support for i18n
 local S = minetest.get_translator("vines")

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -40,11 +40,20 @@ vines.register_vine = function( name, defs, biome )
 	local vine_image_middle = "vines_" .. name .. "_middle.png"
 	local drop_node = vine_name_end
 
-	biome.spawn_plants = {vine_name_end}
+	local spawn_plants = function(pos, fdir)
+		local max_length = math.random(defs.average_length)
+		local current_length = 0
+		while minetest.get_node({ x=pos.x, y=pos.y - 1, z=pos.z }).name == 'air' and current_length < max_length do
+			minetest.swap_node(pos, { name = vine_name_middle, param2 = fdir })
+			pos.y = pos.y - 1
+			current_length = current_length + 1
+		end
+		minetest.swap_node(pos, { name = vine_name_end, param2 = fdir })
+	end
 
 	local vine_group = 'group:' .. name .. '_vines'
 
-	biome.spawn_surfaces[#biome.spawn_surfaces + 1] = vine_group
+	biome.surface[#biome.surface + 1] = vine_group
 
 	local selection_box = {type = "wallmounted",}
 	local drawtype = 'signlike'
@@ -133,7 +142,7 @@ vines.register_vine = function( name, defs, biome )
 		end,
 	})
 
-	biome_lib.register_active_spawner(biome)
+    biome_lib.register_on_generate(biome, spawn_plants)
 end
 
 -- ALIASES
@@ -321,12 +330,10 @@ vines.register_vine('root',
 	choose_random_wall = true,
 	avoid_nodes = {"vines:root_middle"},
 	avoid_radius = 5,
-	spawn_delay = 500,
-	spawn_chance = 10,
-	spawn_surfaces = spawn_root_surfaces,
+	surface = spawn_root_surfaces,
 	spawn_on_bottom = true,
 	plantlife_limit = -0.6,
-	humidity_min = 0.4,
+--	humidity_min = 0.4,
 })
 
 vines.register_vine('vine',
@@ -334,9 +341,7 @@ vines.register_vine('vine',
 	choose_random_wall = true,
 	avoid_nodes = {"group:vines"},
 	avoid_radius = 5,
-	spawn_delay = 500,
-	spawn_chance = 100,
-	spawn_surfaces = {
+	surface = {
 --		"default:leaves",
 		"default:jungleleaves",
 		"moretrees:jungletree_leaves_red",
@@ -345,7 +350,7 @@ vines.register_vine('vine',
 	},
 	spawn_on_bottom = true,
 	plantlife_limit = -0.9,
-	humidity_min = 0.7,
+--	humidity_min = 0.7,
 })
 
 vines.register_vine('side',
@@ -353,9 +358,7 @@ vines.register_vine('side',
 	choose_random_wall = true,
 	avoid_nodes = {"group:vines", "default:apple"},
 	avoid_radius = 3,
-	spawn_delay = 500,
-	spawn_chance = 100,
-	spawn_surfaces = {
+	surface = {
 --		"default:leaves",
 		"default:jungleleaves",
 		"moretrees:jungletree_leaves_red",
@@ -364,7 +367,7 @@ vines.register_vine('side',
 	},
 	spawn_on_side = true,
 	plantlife_limit = -0.9,
-	humidity_min = 0.4,
+--	humidity_min = 0.4,
 })
 
 vines.register_vine("jungle",
@@ -381,15 +384,13 @@ vines.register_vine("jungle",
 		"vines:jungle_end",
 	},
 	avoid_radius = 5,
-	spawn_delay = 500,
-	spawn_chance = 100,
-	spawn_surfaces = {
+	surface = {
 		"default:jungletree",
 		"moretrees:jungletree_trunk"
 	},
 	spawn_on_side = true,
 	plantlife_limit = -0.9,
-	humidity_min = 0.2,
+--	humidity_min = 0.2,
 })
 
 vines.register_vine( 'willow',
@@ -402,11 +403,9 @@ vines.register_vine( 'willow',
 	near_nodes_count = 1,
 	near_nodes_vertical = 7,
 	plantlife_limit = -0.8,
-	spawn_chance = 10,
-	spawn_delay = 500,
 	spawn_on_side = true,
-	spawn_surfaces = {"moretrees:willow_leaves"},
-	humidity_min = 0.5
+	surface = {"moretrees:willow_leaves"},
+--	humidity_min = 0.5
 })
 
 

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -17,6 +17,9 @@ local rarity_side = tonumber(minetest.settings:get("vines_rarity_side")) or defa
 local rarity_jungle = tonumber(minetest.settings:get("vines_rarity_jungle")) or default_rarity
 local rarity_willow = tonumber(minetest.settings:get("vines_rarity_willow")) or default_rarity
 
+local growth_min = 60 * 3
+local growth_max = 60 * 6
+
 -- support for i18n
 local S = minetest.get_translator("vines")
 
@@ -50,6 +53,7 @@ local function ensure_vine_end(pos, oldnode)
 
 	if minetest.get_item_group(nn.name, "vines") > 0 then
 		minetest.swap_node(np, { name = vine_name_end, param2 = oldnode.param2 })
+		minetest.registered_items[vine_name_end].on_construct(np, minetest.get_node(np))
 	end
 end
 
@@ -71,7 +75,7 @@ vines.register_vine = function( name, defs, biome )
 			pos.y = pos.y - 1
 			current_length = current_length + 1
 		end
-		minetest.swap_node(pos, { name = vine_name_end, param2 = fdir })
+		minetest.set_node(pos, { name = vine_name_end, param2 = fdir })
 	end
 
 	local vine_group = 'group:' .. name .. '_vines'
@@ -111,7 +115,7 @@ vines.register_vine = function( name, defs, biome )
 		on_construct = function(pos)
 
 			local timer = minetest.get_node_timer(pos)
-			timer:start(math.random(5, 10))
+			timer:start(math.random(growth_min, growth_max))
 		end,
 
 		on_timer = function(pos)
@@ -121,9 +125,9 @@ vines.register_vine = function( name, defs, biome )
 			local bottom_node = minetest.get_node( bottom )
 			if bottom_node.name == "air" then
 
-				if not math.random(defs.average_length) == 1 then
+				if math.random(defs.average_length) ~= 1 then
 
-					minetest.set_node(pos, {
+					minetest.swap_node(pos, {
 							name = vine_name_middle, param2 = node.param2})
 
 					minetest.set_node(bottom, {
@@ -131,7 +135,7 @@ vines.register_vine = function( name, defs, biome )
 
 					local timer = minetest.get_node_timer(bottom_node)
 
-					timer:start(math.random(5, 10))
+					timer:start(math.random(growth_min, growth_max))
 				end
 			end
 		end,

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -33,6 +33,27 @@ minetest.register_craftitem("vines:vines", {
 
 -- FUNCTIONS
 
+local function on_dig(pos, node, player)
+	wielded_item = player:get_wielded_item()
+	if wielded_item and wielded_item:get_name() == 'vines:shears' then
+		wielded_item:add_wear(1)
+
+		vine_name_end = node.name:gsub("_middle", "_end")
+		minetest.remove_node(pos)
+		minetest.handle_node_drops(pos, {vine_name_end}, player)
+
+		below_pos = {x = pos.x, y = pos.y - 1, z = pos.z}
+		while minetest.get_item_group(minetest.get_node(below_pos).name, "vines") > 0 do
+			minetest.remove_node(below_pos)
+			minetest.handle_node_drops(below_pos, {vine_name_end}, player)
+			below_pos.y = below_pos.y - 1
+		end
+
+	else
+		minetest.node_dig(pos, node, player)
+	end
+end
+
 local function dig_down(pos, node, digger)
 
 	if digger == nil then return end
@@ -140,6 +161,8 @@ vines.register_vine = function( name, defs, biome )
 			end
 		end,
 
+		on_dig = on_dig,
+
 		after_dig_node = function(pos, node, metadata, digger)
 			dig_down(pos, node, digger)
 		end,
@@ -165,6 +188,8 @@ vines.register_vine = function( name, defs, biome )
 		groups = groups,
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = selection_box,
+
+		on_dig = on_dig,
 
 		after_dig_node = function(pos, node, metadata, digger)
 			dig_down(pos, node, digger)

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -381,6 +381,9 @@ if enable_roots ~= false then
 		rarity = rarity_roots,
 	--	humidity_min = 0.4,
 	})
+else
+	minetest.register_alias('vines:root_middle', 'air')
+	minetest.register_alias('vines:root_end', 'air')
 end
 
 if enable_standard ~= false then
@@ -401,6 +404,9 @@ if enable_standard ~= false then
 		rarity = rarity_standard,
 	--	humidity_min = 0.7,
 	})
+else
+	minetest.register_alias('vines:vine_middle', 'air')
+	minetest.register_alias('vines:vine_end', 'air')
 end
 
 if enable_side ~= false then
@@ -421,6 +427,9 @@ if enable_side ~= false then
 		rarity = rarity_side,
 	--	humidity_min = 0.4,
 	})
+else
+	minetest.register_alias('vines:side_middle', 'air')
+	minetest.register_alias('vines:side_end', 'air')
 end
 
 if enable_jungle ~= false then
@@ -447,6 +456,9 @@ if enable_jungle ~= false then
 		rarity = rarity_jungle,
 	--	humidity_min = 0.2,
 	})
+else
+	minetest.register_alias('vines:jungle_middle', 'air')
+	minetest.register_alias('vines:jungle_end', 'air')
 end
 
 if enable_willow ~= false then
@@ -465,6 +477,9 @@ if enable_willow ~= false then
 		rarity = rarity_willow,
 	--	humidity_min = 0.5
 	})
+else
+	minetest.register_alias('vines:willow_middle', 'air')
+	minetest.register_alias('vines:willow_end', 'air')
 end
 
 print("[Vines] Loaded")

--- a/vines/settingtypes.txt
+++ b/vines/settingtypes.txt
@@ -1,3 +1,6 @@
+#Enable the vines item
+vines_enable_vines (Enable vines item) bool true
+
 #Enables ropes made of vine.
 vines_enable_rope (Enable vine ropes) bool true
 

--- a/vines/settingtypes.txt
+++ b/vines/settingtypes.txt
@@ -1,0 +1,32 @@
+#Enables ropes made of vine.
+vines_enable_rope (Enable vine ropes) bool true
+
+#Enables root vines.
+vines_enable_roots (Enable root vines) bool true
+
+#Rarity of root vines, from 1 to 100, higher numbers are rarer.
+vines_rarity_roots (Rarity of roots vines) int 90 1 100
+
+#Enables the standard type of vines.
+vines_enable_standard (Enable standard vines) bool true
+
+#Rarity of standard vines, from 1 to 100, higher numbers are rarer.
+vines_rarity_standard (Rarity of standard vines) int 90 1 100
+
+#Enables the type of vines that grow on the sides of leaf blocks.
+vines_enable_side (Enable side vines) bool true
+
+#Rarity of side vines, from 1 to 100, higher numbers are rarer.
+vines_rarity_side (Rarity of side vines) int 90 1 100
+
+#Enables jungle style vines.
+vines_enable_jungle (Enable jungle vines) bool true
+
+#Rarity of jungle vines, from 1 to 100, higher numbers are rarer.
+vines_rarity_jungle (Rarity of jungle vines) int 90 1 100
+
+#Enables willow vines.
+vines_enable_willow (Enable willow vines) bool true
+
+#Rarity of willow vines, from 1 to 100, higher numbers are rarer.
+vines_rarity_willow (Rarity of willow vines) int 90 1 100

--- a/vines/settingtypes.txt
+++ b/vines/settingtypes.txt
@@ -33,3 +33,9 @@ vines_enable_willow (Enable willow vines) bool true
 
 #Rarity of willow vines, from 1 to 100, higher numbers are rarer.
 vines_rarity_willow (Rarity of willow vines) int 90 1 100
+
+#Vine growth speed, minimum number of seconds between each growth.
+vines_growth_min (Minimum number of seconds between growth) int 180 1 3600
+
+#Vine growth speed, maximum number of seconds between each growth.
+vines_growth_max (Maximum number of seconds between growth) int 360 1 3600


### PR DESCRIPTION
This is a significant overhaul of the Vines mod, and requires this modification to biome_lib to work:
https://github.com/mt-mods/biome_lib/pull/2

CHANGES
1. Vines now generate at mapgen time. Each vine is generated with a random length between 1 and `average_length`.
2. When vines are cut with shears, they give the player the piece of actual vine they cut (the end piece, if they cut the middle piece). This means players can now get vine end nodes and plant them themselves to make a vine farm.

FIXES
1. Growth now works!
2. When a vine is destroyed, we always ensure that any remaining vine above the destroyed vine ends with a vine end node, rather than a middle.
3. Removed the `attached_node` group, as this was causing the following behaviour: When a vine is touched at all, the entire vine instantly breaks, all the way up to the top. Removing this group results in vines behaving exactly as desired.

SETTINGS
1. Settings added to enable or disable any vine type from existing. Any existing disabled vine nodes will be turned to air.
2. Settings added to control the rarity of each vine type.
3. Settings added to control the growth speed of vines.
4. Setting added to enable or disable the vine rope item, as these are unnecessary if you're using a mod such as `ropes`.
5. Setting added to enable or disable whether or not the "vines:vines" item exists. This is because this item is arguably redundant. Any recipe using vines I can find uses the vines group, meaning the vine end nodes you get with shears works. Disabling this item means digging vines ALWAYS gives the user the vine end node.

NOTES
1. Currently, the humidity requirements are disabled, this is because of a problem with humidity in biome_lib: https://github.com/mt-mods/biome_lib/issues/3 - Once a solution is found to that problem, I'll enable and adjust the humidity settings for vines, as well as any other mod that uses biome_lib's humidity and temperature.
2. I would argue that the "vines:vines" item should be disabled by default, or even just removed altogether, as I see no reason for it to exist. I might be wrong though, so I've left it enabled by default.
3. I'm not sure why jungle vines are the colour they are, they're very visually jarring as they're a much, much brighter green than jungle leaves with the default texture pack. I get much more pleasing results disabling them from appearing. Maybe these can be disabled by default, or removed altogether?