### PR TITLE
Rarity / fertility settings for various mods

### DIFF
--- a/bushes/init.lua
+++ b/bushes/init.lua
@@ -8,30 +8,39 @@
 
 -- support for i18n
 local S = minetest.get_translator("bushes")
-  abstract_bushes = {}
+abstract_bushes = {}
 
-  minetest.register_node("bushes:youngtree2_bottom", {
+local bushes_bush_rarity = tonumber(minetest.settings:get("bushes_bush_rarity")) or 99.9
+local bushes_bush_rarity_fertility = tonumber(minetest.settings:get("bushes_bush_rarity_fertility")) or 1.5
+local bushes_bush_fertility = tonumber(minetest.settings:get("bushes_bush_fertility")) or -1
+
+local bushes_youngtrees_rarity = tonumber(minetest.settings:get("bushes_youngtrees_rarity")) or 100
+local bushes_youngtrees_rarity_fertility = tonumber(minetest.settings:get("bushes_youngtrees_rarity_fertility")) or 0.6
+local bushes_youngtrees_fertility = tonumber(minetest.settings:get("bushes_youngtrees_fertility")) or -0.5
+
+
+minetest.register_node("bushes:youngtree2_bottom", {
 	description = S("Young Tree 2 (bottom)"),
- drawtype="nodebox",
- tiles = {"bushes_youngtree2trunk.png"},
+	drawtype="nodebox",
+	tiles = {"bushes_youngtree2trunk.png"},
 	inventory_image = "bushes_youngtree2trunk_inv.png",
 	wield_image = "bushes_youngtree2trunk_inv.png",
-paramtype = "light",
+	paramtype = "light",
 	walkable = false,
 	is_ground_content = true,
-node_box = {
-	type = "fixed",
-	fixed = {
-		--{0.375000,-0.500000,-0.500000,0.500000,0.500000,-0.375000}, --NodeBox 1
-		{-0.0612,-0.500000,-0.500000,0.0612,0.500000,-0.375000}, --NodeBox 1
-	}
-},
+	node_box = {
+		type = "fixed",
+		fixed = {
+			--{0.375000,-0.500000,-0.500000,0.500000,0.500000,-0.375000}, --NodeBox 1
+			{-0.0612,-0.500000,-0.500000,0.0612,0.500000,-0.375000}, --NodeBox 1
+		}
+	},
 	groups = {snappy=3,flammable=2,attached_node=1},
 	sounds = default.node_sound_leaves_defaults(),
 	drop = 'default:stick'
 })
 
-  local BushBranchCenter			= { {1,1}, {3,2} }
+local BushBranchCenter			= { {1,1}, {3,2} }
 for i in pairs(BushBranchCenter) do
 	local Num		= BushBranchCenter[i][1]
 	local TexNum	= BushBranchCenter[i][2]
@@ -55,8 +64,8 @@ for i in pairs(BushBranchCenter) do
 		},
 		inventory_image = "bushes_branches_center_"..TexNum..".png",
 		paramtype = "light",
-			paramtype2 = "facedir",
-				sunlight_propagates = true,
+		paramtype2 = "facedir",
+		sunlight_propagates = true,
 		groups = {
 		--	tree=1, -- MM: disabled because some recipes use group:tree for trunks
 			snappy=3,
@@ -81,16 +90,16 @@ for i in pairs(BushBranchSide) do
 --[[bottom]]"bushes_branches_center_"..TexNum..".png",
 --[[right]]	"bushes_branches_left_"..TexNum..".png",
 --[[left]]	"bushes_branches_right_"..TexNum..".png", -- MM: We could also mirror the previous here,
---[[back]]	"bushes_branches_center_"..TexNum..".png",--     unless U really want 'em 2 B different
+--[[back]]	"bushes_branches_center_"..TexNum..".png",--		 unless U really want 'em 2 B different
 --[[front]]	"bushes_branches_right_"..TexNum..".png"
 		},
 		node_box = {
 			type = "fixed",
 			fixed = {
---				{ left	 , bottom  , front, right   , top     , back    }
-				{0.137748,-0.491944, 0.5  ,-0.125000,-0.179444,-0.007790}, --NodeBox 1
-				{0.262748,-0.185995, 0.5  ,-0.237252, 0.126505,-0.260269}, --NodeBox 2
-				{0.500000, 0.125000, 0.5  ,-0.500000, 0.500000,-0.500000}, --NodeBox 3
+--				{ left	 , bottom	, front, right	 , top		 , back		}
+				{0.137748,-0.491944, 0.5	,-0.125000,-0.179444,-0.007790}, --NodeBox 1
+				{0.262748,-0.185995, 0.5	,-0.237252, 0.126505,-0.260269}, --NodeBox 2
+				{0.500000, 0.125000, 0.5	,-0.500000, 0.500000,-0.500000}, --NodeBox 3
 			},
 		},
 		selection_box = {
@@ -99,8 +108,8 @@ for i in pairs(BushBranchSide) do
 		},
 		inventory_image = "bushes_branches_right_"..TexNum..".png",
 		paramtype = "light",
-			paramtype2 = "facedir",
-				sunlight_propagates = true,
+		paramtype2 = "facedir",
+		sunlight_propagates = true,
 		groups = {
 		--	tree=1, -- MM: disabled because some recipes use group:tree for trunks
 			snappy=3,
@@ -160,9 +169,8 @@ abstract_bushes.grow_bush = function(pos)
 abstract_bushes.grow_bush_node(pos,5,leaf_type)
 end
 
+
 abstract_bushes.grow_bush_node = function(pos,dir, leaf_type)
-
-
 	local right_here = {x=pos.x, y=pos.y+1, z=pos.z}
 	local above_right_here = {x=pos.x, y=pos.y+2, z=pos.z}
 
@@ -184,7 +192,7 @@ abstract_bushes.grow_bush_node = function(pos,dir, leaf_type)
 		dir = 1
 	end
 
-	if minetest.get_node(right_here).name == "air"  -- instead of check_air = true,
+	if minetest.get_node(right_here).name == "air"	-- instead of check_air = true,
 	or minetest.get_node(right_here).name == "default:junglegrass" then
 		minetest.swap_node(right_here, {name="bushes:bushbranches"..bush_branch_type , param2=dir})
 						--minetest.chat_send_all("leaf_type: (" .. leaf_type .. ")")
@@ -200,63 +208,59 @@ end
 
 
 biome_lib.register_on_generate({
-    surface = {
-		"default:dirt_with_grass",
-		"stoneage:grass_with_silex",
-		"sumpf:peat",
-		"sumpf:sumpf"
+		surface = {
+			"default:dirt_with_grass",
+			"stoneage:grass_with_silex",
+			"sumpf:peat",
+			"sumpf:sumpf"
+		},
+		rarity = bushes_bush_rarity,
+		rarity_fertility = bushes_bush_rarity_fertility,
+		plantlife_limit = bushes_bush_fertility,
+		min_elevation = 1, -- above sea level
 	},
-    max_count = 15,  --10,15
-    rarity = 101 - 4,  --3,4
-    min_elevation = 1, -- above sea level
-	plantlife_limit = -0.9,
-  },
-  abstract_bushes.grow_bush
+	abstract_bushes.grow_bush
 )
 
- abstract_bushes.grow_youngtree2 = function(pos)
+abstract_bushes.grow_youngtree2 = function(pos)
 	local height = math.random(4,5)
 	abstract_bushes.grow_youngtree_node2(pos,height)
 end
 
+
 abstract_bushes.grow_youngtree_node2 = function(pos, height)
-
-
 	local right_here = {x=pos.x, y=pos.y+1, z=pos.z}
 	local above_right_here = {x=pos.x, y=pos.y+2, z=pos.z}
 	local two_above_right_here = {x=pos.x, y=pos.y+3, z=pos.z}
 	local three_above_right_here = {x=pos.x, y=pos.y+4, z=pos.z}
 
-	if minetest.get_node(right_here).name == "air"  -- instead of check_air = true,
+	if minetest.get_node(right_here).name == "air"	-- instead of check_air = true,
 	or minetest.get_node(right_here).name == "default:junglegrass" then
 		if height == 4 then
-				local two_above_right_here_south = {x=pos.x, y=pos.y+3, z=pos.z-1}
-				local three_above_right_here_south = {x=pos.x, y=pos.y+4, z=pos.z-1}
-				minetest.swap_node(right_here, {name="bushes:youngtree2_bottom"})
-				minetest.swap_node(above_right_here, {name="bushes:youngtree2_bottom"})
-				minetest.swap_node(two_above_right_here, {name="bushes:bushbranches2"  , param2=2})
-				minetest.swap_node(two_above_right_here_south, {name="bushes:bushbranches2"  , param2=0})
-				minetest.swap_node(three_above_right_here, {name="bushes:BushLeaves1" })
-				minetest.swap_node(three_above_right_here_south, {name="bushes:BushLeaves1" })
+			local two_above_right_here_south = {x=pos.x, y=pos.y+3, z=pos.z-1}
+			local three_above_right_here_south = {x=pos.x, y=pos.y+4, z=pos.z-1}
+			minetest.swap_node(right_here, {name="bushes:youngtree2_bottom"})
+			minetest.swap_node(above_right_here, {name="bushes:youngtree2_bottom"})
+			minetest.swap_node(two_above_right_here, {name="bushes:bushbranches2"	, param2=2})
+			minetest.swap_node(two_above_right_here_south, {name="bushes:bushbranches2"	, param2=0})
+			minetest.swap_node(three_above_right_here, {name="bushes:BushLeaves1" })
+			minetest.swap_node(three_above_right_here_south, {name="bushes:BushLeaves1" })
 		end
-
 	end
 end
 
 
 biome_lib.register_on_generate({
-    surface = {
-		"default:dirt_with_grass",
-		"stoneage:grass_with_silex",
-		"sumpf:peat",
-		"sumpf:sumpf"
+		surface = {
+			"default:dirt_with_grass",
+			"stoneage:grass_with_silex",
+			"sumpf:peat",
+			"sumpf:sumpf"
+		},
+		rarity = bushes_youngtrees_rarity,
+		rarity_fertility = bushes_youngtrees_rarity_fertility,
+		plantlife_limit = bushes_youngtrees_fertility,
+		min_elevation = 1, -- above sea level
 	},
-    max_count = 55,  --10,15
-    rarity = 101 - 4,  --3,4
-    min_elevation = 1, -- above sea level
-	plantlife_limit = -0.9,
-  },
-  abstract_bushes.grow_youngtree2
+	abstract_bushes.grow_youngtree2
 )
-
-		--http://dev.minetest.net/Node_Drawtypes

--- a/bushes/settingtypes.txt
+++ b/bushes/settingtypes.txt
@@ -1,0 +1,17 @@
+#Bush rarity %
+bushes_bush_rarity (Bush rarity %) float 99.9 0 100
+
+#How much the rarity is reduced by fertility %
+bushes_bush_rarity_fertility (Bush rarity fertility reduction %) float 1.5 0 100
+
+#Bush minimum fertility (-1 to +1)
+bushes_bush_fertility (Bush minimum fertility) float -0.7 -1 1
+
+#Youngtree (from bushes mod) rarity %
+bushes_youngtrees_rarity (Youngtree bush rarity %) float 100 0 100
+
+#How much the rarity is reduced by fertility %
+bushes_youngtrees_rarity_fertility (Youngtree bush rarity fertility reduction %) float 0.6 0 100
+
+#Youngtree (from bushes mod) minimum fertility (-1 to +1)
+bushes_youngtrees_fertility (Youngtree bush minimum fertility) float -0.5 -1 1

--- a/molehills/init.lua
+++ b/molehills/init.lua
@@ -1,14 +1,13 @@
 -----------------------------------------------------------------------------------------------
-local title		= "Mole Hills"
-local version	= "0.0.3"
-local mname		= "molehills"
------------------------------------------------------------------------------------------------
 -- Idea by Sokomine
 -- Code & textures by Mossmanikin
 
 abstract_molehills = {}
 
-dofile(minetest.get_modpath("molehills").."/molehills_settings.txt")
+local molehills_rarity = tonumber(minetest.settings:get("molehills_rarity")) or 99.5
+local molehills_rarity_fertility = tonumber(minetest.settings:get("molehills_rarity_fertility")) or 1
+local molehills_fertility = tonumber(minetest.settings:get("molehills_fertility")) or -0.6
+
 
 -- support for i18n
 local S = minetest.get_translator("molehills")
@@ -49,11 +48,11 @@ minetest.register_craft({ -- molehills --> dirt
 -- GeNeRaTiNG
 -----------------------------------------------------------------------------------------------
 abstract_molehills.place_molehill = function(pos)
-	local right_here	= {x=pos.x  , y=pos.y+1, z=pos.z  }
-	if  minetest.get_node({x=pos.x+1, y=pos.y, z=pos.z  }).name ~= "air"
-	and minetest.get_node({x=pos.x-1, y=pos.y, z=pos.z  }).name ~= "air"
-	and minetest.get_node({x=pos.x  , y=pos.y, z=pos.z+1}).name ~= "air"
-	and minetest.get_node({x=pos.x  , y=pos.y, z=pos.z-1}).name ~= "air"
+	local right_here	= {x=pos.x	, y=pos.y+1, z=pos.z	}
+	if	minetest.get_node({x=pos.x+1, y=pos.y, z=pos.z	}).name ~= "air"
+	and minetest.get_node({x=pos.x-1, y=pos.y, z=pos.z	}).name ~= "air"
+	and minetest.get_node({x=pos.x	, y=pos.y, z=pos.z+1}).name ~= "air"
+	and minetest.get_node({x=pos.x	, y=pos.y, z=pos.z-1}).name ~= "air"
 	and minetest.get_node({x=pos.x+1, y=pos.y, z=pos.z+1}).name ~= "air"
 	and minetest.get_node({x=pos.x+1, y=pos.y, z=pos.z-1}).name ~= "air"
 	and minetest.get_node({x=pos.x-1, y=pos.y, z=pos.z+1}).name ~= "air"
@@ -63,18 +62,14 @@ abstract_molehills.place_molehill = function(pos)
 end
 
 biome_lib.register_on_generate({
-    surface = {"default:dirt_with_grass"},
-    max_count = Molehills_Max_Count,
-    rarity = Molehills_Rarity,
-    min_elevation = 1,
-	max_elevation = 40,
-	avoid_nodes = {"group:tree","group:liquid","group:stone","group:falling_node"--[[,"air"]]},
-	avoid_radius = 4,
-    plantlife_limit = -0.3,
-  },
-  abstract_molehills.place_molehill
+		surface = {"default:dirt_with_grass"},
+		rarity = molehills_rarity,
+		rarity_fertility = molehills_rarity_fertility,
+		plantlife_limit = molehills_fertility,
+		min_elevation = 1,
+		max_elevation = 40,
+		avoid_nodes = {"group:tree","group:liquid","group:stone","group:falling_node"--[[,"air"]]},
+		avoid_radius = 4,
+	},
+	abstract_molehills.place_molehill
 )
-
------------------------------------------------------------------------------------------------
-print("[Mod] "..title.." ["..version.."] ["..mname.."]".."Loaded...")
------------------------------------------------------------------------------------------------

--- a/molehills/molehills_settings.txt
+++ b/molehills/molehills_settings.txt
@@ -1,6 +1,0 @@
--- Settings for generation of stuff (at map-generation time)
-
-Molehills_Max_Count		= 320 -- absolute maximum number in an area of 80x80x80 nodes
-
-Molehills_Rarity		= 95 -- larger values make molehills more rare (100 means chance of 0 %)
-

--- a/molehills/settingtypes.txt
+++ b/molehills/settingtypes.txt
@@ -1,0 +1,8 @@
+#Molehills rarity %
+molehills_rarity (Molehills rarity %) float 99.5 0 100
+
+#How much the rarity is reduced by fertility %
+molehills_rarity_fertility (Molehills rarity fertility reduction %) float 1 0 100
+
+#Molehills minimum fertility (-1 to +1)
+molehills_fertility (Molehills minimum fertility) float -0.6 -1 1

--- a/vines/init.lua
+++ b/vines/init.lua
@@ -11,8 +11,8 @@ local enable_side = minetest.settings:get_bool("vines_enable_side", true)
 local enable_jungle = minetest.settings:get_bool("vines_enable_jungle", true)
 local enable_willow = minetest.settings:get_bool("vines_enable_willow", true)
 
-local default_rarity = 75
-local rarity_roots = tonumber(minetest.settings:get("vines_rarity_roots")) or default_rarity
+local rarity_roots = tonumber(minetest.settings:get("vines_rarity_roots")) or 70
+local default_rarity = 95
 local rarity_standard = tonumber(minetest.settings:get("vines_rarity_standard")) or default_rarity
 local rarity_side = tonumber(minetest.settings:get("vines_rarity_side")) or default_rarity
 local rarity_jungle = tonumber(minetest.settings:get("vines_rarity_jungle")) or default_rarity
@@ -371,6 +371,7 @@ if enable_roots ~= false then
 		spawn_on_bottom = true,
 		plantlife_limit = -0.6,
 		rarity = rarity_roots,
+		tries = 3,
 		humidity_min = 0.4,
 		temp_min = 0.4,
 	})
@@ -395,6 +396,7 @@ if enable_standard ~= false then
 		spawn_on_bottom = true,
 		plantlife_limit = -0.9,
 		rarity = rarity_standard,
+		tries = 1,
 		humidity_min = 0.7,
 		temp_min = 0.4,
 	})
@@ -419,6 +421,7 @@ if enable_side ~= false then
 		spawn_on_side = true,
 		plantlife_limit = -0.9,
 		rarity = rarity_side,
+		tries = 1,
 		humidity_min = 0.4,
 		temp_min = 0.4,
 	})
@@ -451,6 +454,7 @@ if enable_jungle ~= false then
 		spawn_on_side = true,
 		plantlife_limit = -0.9,
 		rarity = rarity_jungle,
+		tries = 1,
 		humidity_min = 0.2,
 		temp_min = 0.3,
 	})
@@ -473,6 +477,7 @@ if enable_willow ~= false then
 		spawn_on_side = true,
 		surface = {"moretrees:willow_leaves"},
 		rarity = rarity_willow,
+		tries = 1,
 		humidity_min = 0.5,
 		temp_min = 0.5,
 	})

--- a/vines/settingtypes.txt
+++ b/vines/settingtypes.txt
@@ -8,31 +8,31 @@ vines_enable_rope (Enable vine ropes) bool true
 vines_enable_roots (Enable root vines) bool true
 
 #Rarity of root vines, from 1 to 100, higher numbers are rarer.
-vines_rarity_roots (Rarity of roots vines) int 75 1 100
+vines_rarity_roots (Rarity of roots vines) float 95 0 100
 
 #Enables the standard type of vines.
 vines_enable_standard (Enable standard vines) bool true
 
 #Rarity of standard vines, from 1 to 100, higher numbers are rarer.
-vines_rarity_standard (Rarity of standard vines) int 75 1 100
+vines_rarity_standard (Rarity of standard vines) float 95 0 100
 
 #Enables the type of vines that grow on the sides of leaf blocks.
 vines_enable_side (Enable side vines) bool true
 
 #Rarity of side vines, from 1 to 100, higher numbers are rarer.
-vines_rarity_side (Rarity of side vines) int 75 1 100
+vines_rarity_side (Rarity of side vines) float 95 0 100
 
 #Enables jungle style vines.
 vines_enable_jungle (Enable jungle vines) bool true
 
 #Rarity of jungle vines, from 1 to 100, higher numbers are rarer.
-vines_rarity_jungle (Rarity of jungle vines) int 75 1 100
+vines_rarity_jungle (Rarity of jungle vines) float 95 0 100
 
 #Enables willow vines.
 vines_enable_willow (Enable willow vines) bool true
 
 #Rarity of willow vines, from 1 to 100, higher numbers are rarer.
-vines_rarity_willow (Rarity of willow vines) int 75 1 100
+vines_rarity_willow (Rarity of willow vines) float 95 0 100
 
 #Vine growth speed, minimum number of seconds between each growth.
 vines_growth_min (Minimum number of seconds between growth) int 180 1 3600

--- a/youngtrees/init.lua
+++ b/youngtrees/init.lua
@@ -1,7 +1,11 @@
 -- support for i18n
 local S = minetest.get_translator("youngtrees")
-
 abstract_youngtrees = {}
+
+local youngtrees_youngtrees_rarity = tonumber(minetest.settings:get("youngtrees_youngtrees_rarity")) or 100
+local youngtrees_youngtrees_rarity_fertility = tonumber(minetest.settings:get("youngtrees_youngtrees_rarity_fertility")) or 0.5
+local youngtrees_youngtrees_fertility = tonumber(minetest.settings:get("youngtrees_youngtrees_fertility")) or -0.3
+
 
 minetest.register_node("youngtrees:bamboo", {
 	description = S("Young Bamboo Tree"),
@@ -40,7 +44,7 @@ minetest.register_node("youngtrees:youngtree2_middle",{
 			{-0.500000,0.125000,-0.500000,0.500000,0.500000,0.500000}, --NodeBox 3
 		}
 	},
-		groups = {snappy=3,flammable=2,attached_node=1},
+	groups = {snappy=3,flammable=2,attached_node=1},
 	sounds = default.node_sound_leaves_defaults(),
 	drop = 'trunks:twig_1'
 })
@@ -63,7 +67,6 @@ minetest.register_node("youngtrees:youngtree_top", {
 	drop = 'trunks:twig_1'
 })
 
-
 minetest.register_node("youngtrees:youngtree_middle", {
 	description = S("Young Tree (middle)"),
 	drawtype = "plantlike",
@@ -81,8 +84,6 @@ minetest.register_node("youngtrees:youngtree_middle", {
 	sounds = default.node_sound_leaves_defaults(),
 	drop = 'trunks:twig_1'
 })
-
-
 
 minetest.register_node("youngtrees:youngtree_bottom", {
 	description = S("Young Tree (bottom)"),
@@ -103,47 +104,46 @@ minetest.register_node("youngtrees:youngtree_bottom", {
 })
 
 
- abstract_youngtrees.grow_youngtree = function(pos)
+abstract_youngtrees.grow_youngtree = function(pos)
 	local height = math.random(1,3)
 	abstract_youngtrees.grow_youngtree_node(pos,height)
 end
 
+
 abstract_youngtrees.grow_youngtree_node = function(pos, height)
-
-
 	local right_here = {x=pos.x, y=pos.y+1, z=pos.z}
 	local above_right_here = {x=pos.x, y=pos.y+2, z=pos.z}
 
-	if minetest.get_node(right_here).name == "air"  -- instead of check_air = true,
+	if minetest.get_node(right_here).name == "air"	-- instead of check_air = true,
 	or minetest.get_node(right_here).name == "default:junglegrass" then
 		if height == 1 then
-				minetest.swap_node(right_here, {name="youngtrees:youngtree_top"})
+			minetest.swap_node(right_here, {name="youngtrees:youngtree_top"})
 		end
 		if height == 2 then
-				minetest.swap_node(right_here, {name="youngtrees:youngtree_bottom"})
-				minetest.swap_node(above_right_here, {name="youngtrees:youngtree_top"})
+			minetest.swap_node(right_here, {name="youngtrees:youngtree_bottom"})
+			minetest.swap_node(above_right_here, {name="youngtrees:youngtree_top"})
 		end
 		if height == 3 then
-				local two_above_right_here = {x=pos.x, y=pos.y+3, z=pos.z}
-				minetest.swap_node(right_here, {name="youngtrees:youngtree_bottom"})
-				minetest.swap_node(above_right_here, {name="youngtrees:youngtree_middle"})
-				minetest.swap_node(two_above_right_here, {name="youngtrees:youngtree_top"})
+			local two_above_right_here = {x=pos.x, y=pos.y+3, z=pos.z}
+			minetest.swap_node(right_here, {name="youngtrees:youngtree_bottom"})
+			minetest.swap_node(above_right_here, {name="youngtrees:youngtree_middle"})
+			minetest.swap_node(two_above_right_here, {name="youngtrees:youngtree_top"})
 		end
 	end
 end
 
 
 biome_lib.register_on_generate({
-    surface = {
-		"default:dirt_with_grass",
-		"stoneage:grass_with_silex",
-		"sumpf:peat",
-		"sumpf:sumpf"
+		surface = {
+			"default:dirt_with_grass",
+			"stoneage:grass_with_silex",
+			"sumpf:peat",
+			"sumpf:sumpf"
+		},
+		rarity = youngtrees_youngtrees_rarity,
+		rarity_fertility = youngtrees_youngtrees_rarity_fertility,
+		plantlife_limit = youngtrees_youngtrees_fertility,
+		min_elevation = 1, -- above sea level
 	},
-    max_count = 55,  --10,15
-    rarity = 101 - 4,  --3,4
-    min_elevation = 1, -- above sea level
-	plantlife_limit = -0.9,
-  },
-  abstract_youngtrees.grow_youngtree
+	abstract_youngtrees.grow_youngtree
 )

--- a/youngtrees/settingtypes.txt
+++ b/youngtrees/settingtypes.txt
@@ -1,0 +1,8 @@
+#Youngtree rarity %
+youngtrees_youngtrees_rarity (Youngtree rarity %) float 100 0 100
+
+#How much the rarity is reduced by fertility %
+youngtrees_youngtrees_rarity_fertility (Youngtree rarity fertility reduction %) float 0.5 0 100
+
+#Youngtree minimum fertility (-1 to +1)
+youngtrees_youngtrees_fertility (Youngtree minimum fertility) float -0.3 -1 1


### PR DESCRIPTION
For bushes, molehills and youngtrees:
Added rarity and rarity_fertility settings.
Changes to rarity and minimum fertility. Result is more balanced and less homogeneous, i.e. over a large area you'll see variation.

For vines, some further tweaks to rarity, and using tries field to improve vines distribution.

Requires this PR for biome_lib:
https://github.com/mt-mods/biome_lib/pull/8