### PR TITLE
fix felling `farns:fern_trunk_big`

### DIFF
--- a/ferns/gianttreefern.lua
+++ b/ferns/gianttreefern.lua
@@ -162,6 +162,14 @@ minetest.register_node("ferns:tree_fern_leave_big", {
 	},
 	drop = "",
 	sounds = default.node_sound_leaves_defaults(),
+	after_destruct = function(pos,oldnode)
+		for _, d in pairs({{x=-1,z=0},{x=1,z=0},{x=0,z=-1},{x=0,z=1}}) do
+			local node = minetest.get_node({x=pos.x+d.x,y=pos.y+1,z=pos.z+d.z})
+			if node.name == "ferns:tree_fern_leave_big" then
+				minetest.dig_node({x=pos.x+d.x,y=pos.y+1,z=pos.z+d.z})
+			end
+		end
+	end,
 })
 
 -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
After felling `farns:fern_trunk_big` the topmost `farns:tree_fern_leave_big` nodes remain.
The reason is that these the topmost leaves are not directly connected to the leaves at `ferns:tree_fern_leave_big_end`. 

This PR fixes the problem by removing `farns:tree_fern_leave_big` at { y+1 , x +/-1 } and { y+1, z +/-1 } after removing `farns: tree_fern_leave_big`.