### PR TITLE
Add `group:sapling` for saplings in plantlife

### DIFF
--- a/dryplants/reedmace.lua
+++ b/dryplants/reedmace.lua
@@ -264,7 +264,8 @@ minetest.register_node("dryplants:reedmace_sapling", {
 	groups = {
 		snappy=3,
 		flammable=2,
-		attached_node=1
+		attached_node=1,
+		sapling=1,
 	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {

--- a/ferns/gianttreefern.lua
+++ b/ferns/gianttreefern.lua
@@ -271,7 +271,7 @@ minetest.register_node("ferns:sapling_giant_tree_fern", {
 	tiles = {"ferns_sapling_tree_fern_giant.png"},
 	inventory_image = "ferns_sapling_tree_fern_giant.png",
 	walkable = false,
-	groups = {snappy=3,flammable=2,flora=1,attached_node=1},
+	groups = {snappy=3,flammable=2,flora=1,attached_node=1,sapling=1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",

--- a/ferns/treefern.lua
+++ b/ferns/treefern.lua
@@ -158,7 +158,7 @@ minetest.register_node("ferns:sapling_tree_fern", {
 	tiles = {"ferns_sapling_tree_fern.png"},
 	inventory_image = "ferns_sapling_tree_fern.png",
 	walkable = false,
-	groups = {snappy=3,flammable=2,flora=1,attached_node=1},
+	groups = {snappy=3,flammable=2,flora=1,attached_node=1,sapling=1},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",


### PR DESCRIPTION
I would like to add in bonemeal support for plantlife saplings.
For this, the saplings would also need to be in the `sapling` group. See https://notabug.org/TenPlus1/bonemeal/src/master/init.lua#L476-L477

I have successfully tested the customization together with https://notabug.org/nixnoxus/bonemeal/commit/d5c75479523f7c77e85cf8ed8413155e736ba53d (Branch https://notabug.org/nixnoxus/bonemeal/src/add_ferns_and_dryplants_support)
