### PR TITLE
limit bush duping

### DIFF
--- a/bushes_classic/nodes.lua
+++ b/bushes_classic/nodes.lua
@@ -63,7 +63,7 @@ plantlife_bushes.after_dig_node = function(pos, oldnode, oldmetadata, digger)
 
 		-- with a chance of 1/3, return 2 bushes
 		local amount
-		if math.random(1,3) == 1 then
+		if can_harvest and math.random(1,3) == 1 then
 			amount = "2"
 		else
 			amount = "1"


### PR DESCRIPTION
only allow a chance of getting a 2nd bush from bushes with fruit, to prevent instant bush duping.