### PR TITLE
remove biome lib usage from molehills

### DIFF
--- a/molehills/init.lua
+++ b/molehills/init.lua
@@ -2,13 +2,6 @@
 -- Idea by Sokomine
 -- Code & textures by Mossmanikin
 
-abstract_molehills = {}
-
-local molehills_rarity = tonumber(minetest.settings:get("molehills_rarity")) or 99.5
-local molehills_rarity_fertility = tonumber(minetest.settings:get("molehills_rarity_fertility")) or 1
-local molehills_fertility = tonumber(minetest.settings:get("molehills_fertility")) or -0.6
-
-
 -- support for i18n
 local S = minetest.get_translator("molehills")
 -----------------------------------------------------------------------------------------------
@@ -48,29 +41,18 @@ minetest.register_craft({ -- molehills --> dirt
 -----------------------------------------------------------------------------------------------
 -- GeNeRaTiNG
 -----------------------------------------------------------------------------------------------
-abstract_molehills.place_molehill = function(pos)
-	local right_here	= {x=pos.x	, y=pos.y+1, z=pos.z	}
-	if	minetest.get_node({x=pos.x+1, y=pos.y, z=pos.z	}).name ~= "air"
-	and minetest.get_node({x=pos.x-1, y=pos.y, z=pos.z	}).name ~= "air"
-	and minetest.get_node({x=pos.x	, y=pos.y, z=pos.z+1}).name ~= "air"
-	and minetest.get_node({x=pos.x	, y=pos.y, z=pos.z-1}).name ~= "air"
-	and minetest.get_node({x=pos.x+1, y=pos.y, z=pos.z+1}).name ~= "air"
-	and minetest.get_node({x=pos.x+1, y=pos.y, z=pos.z-1}).name ~= "air"
-	and minetest.get_node({x=pos.x-1, y=pos.y, z=pos.z+1}).name ~= "air"
-	and minetest.get_node({x=pos.x-1, y=pos.y, z=pos.z-1}).name ~= "air" then
-		minetest.swap_node(right_here, {name="molehills:molehill"})
-	end
-end
-
-biome_lib.register_on_generate({
-		surface = {"default:dirt_with_grass"},
-		rarity = molehills_rarity,
-		rarity_fertility = molehills_rarity_fertility,
-		plantlife_limit = molehills_fertility,
-		min_elevation = 1,
-		max_elevation = 40,
-		avoid_nodes = {"group:tree","group:liquid","group:stone","group:falling_node"--[[,"air"]]},
-		avoid_radius = 4,
+minetest.register_decoration({
+	decoration = {
+		"molehills:molehill"
 	},
-	abstract_molehills.place_molehill
-)
+	fill_ratio = 0.002,
+	y_min = 1,
+	y_max = 40,
+	place_on = {
+		"default:dirt_with_grass"
+	},
+	spawn_by = "air",
+	num_spawn_by = 1,
+	deco_type = "simple",
+	flags = "all_floors",
+})

--- a/molehills/mod.conf
+++ b/molehills/mod.conf
@@ -1,2 +1,2 @@
 name = molehills
-depends = default, biome_lib
+depends = default

--- a/molehills/settingtypes.txt
+++ b/molehills/settingtypes.txt
@@ -1,8 +1,0 @@
-#Molehills rarity %
-molehills_rarity (Molehills rarity %) float 99.5 0 100
-
-#How much the rarity is reduced by fertility %
-molehills_rarity_fertility (Molehills rarity fertility reduction %) float 1 0 100
-
-#Molehills minimum fertility (-1 to +1)
-molehills_fertility (Molehills minimum fertility) float -0.6 -1 1


### PR DESCRIPTION
ticks another one off the list - https://github.com/mt-mods/plantlife_modpack/issues/27

at time of writing, no one on cdb uses the removed api: https://content.minetest.net/zipgrep/3a7b2603-e548-4572-a23f-cf3e32ad7753/

of a random sampling of ex ve servers, and a few other mt-mods members servers, no one was using the settings removed.