### PR TITLE
replace biome_lib ABM's

### DIFF
--- a/bushes_classic/init.lua
+++ b/bushes_classic/init.lua
@@ -54,21 +54,18 @@ minetest.register_abm({
 	chance = 100,
 	label = "[bushes_classic] spawn bushes",
 	min_y = -16,
-    max_y = 48,
+	max_y = 48,
 	action = function(pos, node)
 		local p_top = {x = pos.x, y = pos.y + 1, z = pos.z}
 		local n_top = minetest.get_node_or_nil(p_top)
-		if not n_top then return end
-		if n_top.name ~= "air" then return end
+		if not n_top or n_top.name ~= "air" then return end
 
 		local perlin_fertile_area = minetest.get_perlin(545342534, 3, 0.6, 100)
 
 		local fertility, temperature, humidity = get_biome_data(pos, perlin_fertile_area)
 
 		local pos_biome_ok = fertility > -0.1 and temperature <= 0.15 and temperature >= -0.15 and humidity <= 0 and humidity >= -1
-		if not pos_biome_ok then
-			return -- Outside of biome
-		end
+		if not pos_biome_ok then return end
 
 		if minetest.find_node_near(p_top, 10 + math.random(-1.5,2), {"group:bush"}) then
 			return -- Nodes to avoid are nearby

--- a/bushes_classic/init.lua
+++ b/bushes_classic/init.lua
@@ -30,12 +30,19 @@ local modpath = minetest.get_modpath('bushes_classic')
 dofile(modpath..'/cooking.lua')
 dofile(modpath..'/nodes.lua')
 
-biome_lib.register_active_spawner({
-	spawn_delay = 3600,
-	spawn_plants = bushes_classic.spawn_list,
-	avoid_radius = 10,
-	spawn_chance = 100,
-	spawn_surfaces = {
+local spawn_plants = bushes_classic.spawn_list
+
+local function get_biome_data(pos, perlin_fertile)
+	local fertility = perlin_fertile:get_2d({x=pos.x, y=pos.z})
+
+	local data = minetest.get_biome_data(pos)
+	-- Original values this method returned were +1 (lowest) to -1 (highest)
+	-- so we need to convert the 0-100 range from get_biome_data() to that.
+	return fertility, 1 - (data.heat / 100 * 2), 1 - (data.humidity / 100 * 2)
+end
+
+minetest.register_abm({
+	nodenames = {
 		"default:dirt_with_grass",
 		"woodsoils:dirt_with_leaves_1",
 		"woodsoils:grass_with_leaves_1",
@@ -43,14 +50,34 @@ biome_lib.register_active_spawner({
 		"farming:soil",
 		"farming:soil_wet"
 	},
-	avoid_nodes = {"group:bush"},
-	seed_diff = 545342534, -- chosen by a fair mashing of the keyboard - guaranteed to be random :P
-	plantlife_limit = -0.1,
-	light_min = 10,
-	temp_min = 0.15, -- approx 20C
-	temp_max = -0.15, -- approx 35C
-	humidity_min = 0, -- 50% RH
-	humidity_max = -1, -- 100% RH
+	interval = 3600,
+	chance = 100,
+	label = "[bushes_classic] spawn bushes",
+	min_y = -16,
+    max_y = 48,
+	action = function(pos, node)
+		local p_top = {x = pos.x, y = pos.y + 1, z = pos.z}
+		local n_top = minetest.get_node_or_nil(p_top)
+		if not n_top then return end
+		if n_top.name ~= "air" then return end
+
+		local perlin_fertile_area = minetest.get_perlin(545342534, 3, 0.6, 100)
+
+		local fertility, temperature, humidity = get_biome_data(pos, perlin_fertile_area)
+
+		local pos_biome_ok = fertility > -0.1 and temperature <= 0.15 and temperature >= -0.15 and humidity <= 0 and humidity >= -1
+		if not pos_biome_ok then
+			return -- Outside of biome
+		end
+
+		if minetest.find_node_near(p_top, 10 + math.random(-1.5,2), {"group:bush"}) then
+			return -- Nodes to avoid are nearby
+		end
+
+		local plant_to_spawn = spawn_plants[math.random(1, #spawn_plants)]
+
+		minetest.swap_node(p_top, {name = plant_to_spawn, param2 = 0})
+	end
 })
 
 minetest.register_alias("bushes:basket_pies", "bushes:basket_strawberry")

--- a/bushes_classic/mod.conf
+++ b/bushes_classic/mod.conf
@@ -1,3 +1,2 @@
 name = bushes_classic
-depends = biome_lib
 optional_depends = farming, farming_plus

--- a/ferns/horsetail.lua
+++ b/ferns/horsetail.lua
@@ -94,8 +94,7 @@ if abstract_ferns.config.enable_horsetails_spawning == true then
 		action = function(pos, node)
 			local p_top = {x = pos.x, y = pos.y + 1, z = pos.z}
 			local n_top = minetest.get_node_or_nil(p_top)
-			if not n_top then return end
-			if n_top.name ~= "air" then return end
+			if not n_top or n_top.name ~= "air" then return end
 
 			local NEAR_DST = 2
 			if #minetest.find_nodes_in_area(

--- a/ferns/horsetail.lua
+++ b/ferns/horsetail.lua
@@ -75,13 +75,10 @@ create_nodes()
 -- Spawning
 -----------------------------------------------------------------------------------------------
 if abstract_ferns.config.enable_horsetails_spawning == true then
-	biome_lib.register_active_spawner({
-		spawn_delay = 1200,
-		spawn_plants = node_names,
-		spawn_chance = 400,
-		spawn_surfaces = {
+	minetest.register_abm({
+		nodenames = {
 			"default:dirt_with_grass",
-			"default:dirt_with_coniferous_litter", -- minetest >= 0.5
+			"default:dirt_with_coniferous_litter",
 			"default:desert_sand",
 			"default:sand",
 			"dryplants:grass_short",
@@ -89,13 +86,29 @@ if abstract_ferns.config.enable_horsetails_spawning == true then
 			"default:mossycobble",
 			"default:gravel"
 		},
-		seed_diff = 329,
-		min_elevation = 1, -- above sea level
-		near_nodes = {"default:water_source","default:river_water_source","default:gravel"},
-		near_nodes_size = 2,
-		near_nodes_vertical = 1,
-		near_nodes_count = 1,
-		--random_facedir = { 0, 179 },
+		interval = 1200,
+		chance = 400,
+		label = "[ferns] spawn horsetails",
+		min_y = 1,
+		max_y = 48,
+		action = function(pos, node)
+			local p_top = {x = pos.x, y = pos.y + 1, z = pos.z}
+			local n_top = minetest.get_node_or_nil(p_top)
+			if not n_top then return end
+			if n_top.name ~= "air" then return end
+
+			local NEAR_DST = 2
+			if #minetest.find_nodes_in_area(
+					{x=pos.x-NEAR_DST, y=pos.y-1, z=pos.z-NEAR_DST},
+					{x=pos.x+NEAR_DST, y=pos.y+1, z=pos.z+NEAR_DST},
+					{"default:water_source","default:river_water_source","default:gravel"}
+				) < 1 then return
+			end
+
+			local plant_to_spawn = node_names[math.random(1, #node_names)]
+
+			minetest.swap_node(p_top, {name = plant_to_spawn, param2 = 0})
+		end
 	})
 end
 

--- a/pl_seaweed/init.lua
+++ b/pl_seaweed/init.lua
@@ -7,7 +7,7 @@ local seaweed_max_count = tonumber(minetest.settings:get("pl_seaweed_max_count")
 local seaweed_rarity = tonumber(minetest.settings:get("pl_seaweed_rarity")) or 33
 
 local function get_ndef(name)
-	return minetest.registered_noes[name] or {}
+	return minetest.registered_nodes[name] or {}
 end
 
 local algae_list = { {nil}, {2}, {3}, {4} }

--- a/pl_seaweed/init.lua
+++ b/pl_seaweed/init.lua
@@ -6,6 +6,9 @@ pl_seaweed = {}
 local seaweed_max_count = tonumber(minetest.settings:get("pl_seaweed_max_count")) or 320
 local seaweed_rarity = tonumber(minetest.settings:get("pl_seaweed_rarity")) or 33
 
+local function get_ndef(name)
+	return minetest.registered_noes[name] or {}
+end
 
 local algae_list = { {nil}, {2}, {3}, {4} }
 
@@ -59,22 +62,21 @@ for i in ipairs(algae_list) do
 			local under_node = minetest.get_node(pt.under)
 			local above_node = minetest.get_node(pt.above)
 			local top_node	 = minetest.get_node(top_pos)
-
-			if biome_lib.get_nodedef_field(under_node.name, "buildable_to") then
+			if get_ndef(under_node.name)["buildable_to"] then
 				if under_node.name ~= "default:water_source" then
 					place_pos = pt.under
-				elseif top_node.name ~= "default:water_source"
-							 and biome_lib.get_nodedef_field(top_node.name, "buildable_to") then
+				elseif top_node.name ~= "default:water_source" and get_ndef(top_node.name)["buildable_to"] then
 					place_pos = top_pos
 				else
 					return
 				end
-			elseif biome_lib.get_nodedef_field(above_node.name, "buildable_to") then
+			elseif get_ndef(above_node.name)["buildable_to"] then
 				place_pos = pt.above
 			end
 			if not place_pos then return end -- something went wrong :P
 
-			if not minetest.is_protected(place_pos, placer:get_player_name()) then
+			local pname = placer:get_player_name()
+			if not minetest.is_protected(place_pos, pname) then
 
 			local nodename = "default:cobble" -- :D
 
@@ -96,7 +98,7 @@ for i in ipairs(algae_list) do
 					minetest.swap_node(place_pos, {name = "flowers:seaweed", param2 = fdir})
 				end
 
-				if not biome_lib.expect_infinite_stacks then
+				if not minetest.is_creative_enabled(pname) then
 					itemstack:take_item()
 				end
 				return itemstack

--- a/pl_waterlilies/init.lua
+++ b/pl_waterlilies/init.lua
@@ -7,7 +7,7 @@ local lilies_max_count = tonumber(minetest.settings:get("pl_waterlilies_max_coun
 local lilies_rarity = tonumber(minetest.settings:get("pl_waterlilies_rarity")) or 33
 
 local function get_ndef(name)
-	return minetest.registered_noes[name] or {}
+	return minetest.registered_nodes[name] or {}
 end
 
 local lilies_list = {

--- a/pl_waterlilies/init.lua
+++ b/pl_waterlilies/init.lua
@@ -6,6 +6,9 @@ pl_waterlilies = {}
 local lilies_max_count = tonumber(minetest.settings:get("pl_waterlilies_max_count")) or 320
 local lilies_rarity = tonumber(minetest.settings:get("pl_waterlilies_rarity")) or 33
 
+local function get_ndef(name)
+	return minetest.registered_noes[name] or {}
+end
 
 local lilies_list = {
 	{ nil	, nil			 , 1	},
@@ -72,20 +75,20 @@ for i in ipairs(lilies_list) do
 			local above_node = minetest.get_node(pt.above)
 			local top_node	 = minetest.get_node(top_pos)
 
-			if biome_lib.get_nodedef_field(under_node.name, "buildable_to") then
+			if get_ndef(under_node.name)["buildable_to"] then
 				if under_node.name ~= "default:water_source" then
 					place_pos = pt.under
-				elseif top_node.name ~= "default:water_source"
-							 and biome_lib.get_nodedef_field(top_node.name, "buildable_to") then
+				elseif top_node.name ~= "default:water_source" and get_ndef(top_node.name)["buildable_to"] then
 					place_pos = top_pos
 				else
 					return
 				end
-			elseif biome_lib.get_nodedef_field(above_node.name, "buildable_to") then
+			elseif get_ndef(above_node.name)["buildable_to"] then
 				place_pos = pt.above
 			end
 
-			if place_pos and not minetest.is_protected(place_pos, placer:get_player_name()) then
+			local pname = placer:get_player_name()
+			if place_pos and not minetest.is_protected(place_pos, pname) then
 
 			local nodename = "default:cobble" -- if this block appears, something went....wrong :-)
 
@@ -114,7 +117,7 @@ for i in ipairs(lilies_list) do
 					minetest.swap_node(place_pos, {name = "flowers:waterlily", param2 = fdir})
 				end
 
-				if not biome_lib.expect_infinite_stacks then
+				if not minetest.is_creative_enabled(pname) then
 					itemstack:take_item()
 				end
 				return itemstack

--- a/poisonivy/init.lua
+++ b/poisonivy/init.lua
@@ -78,7 +78,7 @@ end
 minetest.register_abm({
 	nodenames = {"default:dirt_with_grass"},
 	interval = 1000,
-	chance = 200,
+	chance = 20,
 	label = "[poisoninvy] spawn plants",
 	min_y = -16,
     max_y = 48,
@@ -88,7 +88,7 @@ minetest.register_abm({
 		if not n_top then return end
 		if n_top.name ~= "air" then return end
 
-		local n_light = minetest.get_node_light(p_top, nil)
+		local n_light = minetest.get_node_light(p_top)
 		if n_light < 7 then
 			return
 		end
@@ -109,7 +109,7 @@ minetest.register_abm({
 
 minetest.register_abm({
 	nodenames = {"poisonivy:seedling"},
-	interval = 500,
+	interval = 1000,
 	chance = 30,
 	label = "grow poisonivy",
 	action = function(pos, node)
@@ -117,7 +117,7 @@ minetest.register_abm({
 		local n_top = minetest.get_node(p_top)
 
 		if n_top.name == "air" then
-			minetest.swap_node(p_top, {name = "poisonivy:sproutling"})
+			minetest.swap_node(pos, {name = "poisonivy:sproutling"})
 		end
 	end
 })

--- a/poisonivy/init.lua
+++ b/poisonivy/init.lua
@@ -81,12 +81,11 @@ minetest.register_abm({
 	chance = 20,
 	label = "[poisoninvy] spawn plants",
 	min_y = -16,
-    max_y = 48,
+	max_y = 48,
 	action = function(pos, node)
 		local p_top = {x = pos.x, y = pos.y + 1, z = pos.z}
 		local n_top = minetest.get_node_or_nil(p_top)
-		if not n_top then return end
-		if n_top.name ~= "air" then return end
+		if not n_top or n_top.name ~= "air" then return end
 
 		local n_light = minetest.get_node_light(p_top)
 		if n_light < 7 then

--- a/poisonivy/init.lua
+++ b/poisonivy/init.lua
@@ -93,7 +93,7 @@ minetest.register_abm({
 			return
 		end
 
-		if minetest.find_node_near(p_top, 10 + math.random(-1.5,2), {"group:poisonivy", "group:flower", "group:flora"}) then
+		if minetest.find_node_near(p_top, 10 + math.random(-1.5,2), {"group:poisonivy", "group:flower"}) then
 			return -- Nodes to avoid are nearby
 		end
 

--- a/poisonivy/mod.conf
+++ b/poisonivy/mod.conf
@@ -1,2 +1,2 @@
 name = poisonivy
-depends = biome_lib
+depends = default


### PR DESCRIPTION
next step for https://github.com/mt-mods/plantlife_modpack/issues/27

- Replace biome_lib helperfunctions w/ integrated methodes
- Replace `register_active_spawner` and `update_plant` w/ direct ABM's

Bushes classic bushes do spawn, but they're *yery* rare
~~Poisonivy nodes don't spawn enough yet~~ Edit: Works much better since https://github.com/mt-mods/plantlife_modpack/pull/48/commits/ef782ea5e1b0b69b815de72f4ca407f3f9652d77