### PR TITLE
fix typo for moss aliases

### DIFF
--- a/trunks/nodes.lua
+++ b/trunks/nodes.lua
@@ -126,8 +126,8 @@ for r = 0, 3 do
 	})
 end
 
-minetest.register_alias("trunks:moss_plain", "trunks:moss_plain_0")
-minetest.register_alias("trunks:moss_with_fungus", "trunks:moss_with_fungus_0")
+minetest.register_alias("trunks:moss", "trunks:moss_plain_0")
+minetest.register_alias("trunks:moss_fungus", "trunks:moss_with_fungus_0")
 
 -----------------------------------------------------------------------------------------------
 -- TWiGS BLoCK


### PR DESCRIPTION
when `trunks:moss` and `trunks:moss_fungus` were removed/renamed in
f01e4bb55f0e774a867d45451e6c837a1d40c244, the wrong aliases got registered.

Thus players might see (and in case of high lag even obtain) the unknown nodes before the lbm kicks in and replaces them.