### PR TITLE
Fix vines nodetimer never starting on new nodes

### DIFF
--- a/vines/init.lua
+++ b/vines/init.lua
@@ -197,7 +197,7 @@ vines.register_vine = function( name, defs, def )
 					minetest.set_node(bottom, {
 							name = node.name, param2 = node.param2})
 
-					local timer = minetest.get_node_timer(bottom_node)
+					local timer = minetest.get_node_timer(bottom)
 
 					timer:start(math.random(growth_min, growth_max))
 				end


### PR DESCRIPTION
`get_node_timer` requires the position not the node's name (see lines 188,189).

git blame says this broke at least 7 (!) years ago in https://github.com/mt-mods/plantlife_modpack/commit/feb3092d060f0bcab2cf7052b699f49ea389a869