### PR TITLE
`nature_classic`: Fix apples not leafdecaying

### DIFF
--- a/nature_classic/blossom.lua
+++ b/nature_classic/blossom.lua
@@ -26,7 +26,7 @@ minetest.register_node(":"..nature.blossom_node, {
 
 default.register_leafdecay({
 	trunks = { nature.blossom_trunk },
-	leaves = { nature.blossom_node, nature.blossom_leaves },
+	leaves = { nature.blossom_node, nature.blossom_leaves, nature.blossom_fruit },
 	radius = nature.blossom_decay,
 })
 

--- a/nature_classic/init.lua
+++ b/nature_classic/init.lua
@@ -14,6 +14,7 @@ nature.blossom_decay = 2
 nature.blossom_trunk = "default:tree"
 nature.blossom_node = "nature:blossom"
 nature.blossom_leaves = "default:leaves"
+nature.blossom_fruit = "default:apple"
 nature.blossom_textures = { "default_leaves.png^nature_blossom.png" }
 nature.blossom_groups = { snappy = 3, leafdecay = 1, leaves = 1, flammable = 2 }
 


### PR DESCRIPTION
Adds `nature.blossom_fruit` variable, set to `default:apple`. Fixes https://github.com/mt-mods/plantlife_modpack/issues/78.